### PR TITLE
Mt grammar declare

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -94,7 +94,7 @@ let rec string_of_expr = function
       "{" ^ string_of_expr e1 ^ ", " ^ string_of_expr e2 ^ ", " ^ string_of_expr e3 ^ "}"
 
 let rec string_of_stmt = function
-    Block(vdecls, stmts) ->
+    Block(_, stmts) ->
       "{\n" ^ String.concat "" (List.map string_of_stmt stmts) ^ "}\n"
   | Expr(expr) -> string_of_expr expr ^ ";\n";
   | Return(expr) -> "return " ^ string_of_expr expr ^ ";\n";

--- a/ast.ml
+++ b/ast.ml
@@ -27,7 +27,7 @@ type expr =
   | Inf
 
 type stmt =
-    Block of stmt list
+    Block of (bind list * stmt list)
   | Expr of expr
   | Return of expr
   | If of expr * stmt * stmt
@@ -94,11 +94,11 @@ let rec string_of_expr = function
       "{" ^ string_of_expr e1 ^ ", " ^ string_of_expr e2 ^ ", " ^ string_of_expr e3 ^ "}"
 
 let rec string_of_stmt = function
-    Block(stmts) ->
+    Block(vdecls, stmts) ->
       "{\n" ^ String.concat "" (List.map string_of_stmt stmts) ^ "}\n"
   | Expr(expr) -> string_of_expr expr ^ ";\n";
   | Return(expr) -> "return " ^ string_of_expr expr ^ ";\n";
-  | If(e, s, Block([])) -> "if (" ^ string_of_expr e ^ ")\n" ^ string_of_stmt s
+  | If(e, s, Block([], [])) -> "if (" ^ string_of_expr e ^ ")\n" ^ string_of_stmt s
   | If(e, s1, s2) ->  "if (" ^ string_of_expr e ^ ")\n" ^
       string_of_stmt s1 ^ "else\n" ^ string_of_stmt s2
   | For(e1, e2, e3, s) ->

--- a/ast.ml
+++ b/ast.ml
@@ -118,7 +118,7 @@ let rec string_of_typ = function
   | Curve -> "curve"
   | Point -> "point"
   | Void -> "void"
-  | Pointer _ as t -> "pointer " ^ string_of_typ(t)
+  | Pointer (_ as t) -> "pointer " ^ string_of_typ(t)
 
 let string_of_vdecl (t, id) = string_of_typ t ^ " " ^ id ^ ";\n"
 

--- a/codegen.ml
+++ b/codegen.ml
@@ -149,7 +149,7 @@ let translate (globals, functions) =
     (* Build the code for the given statement; return the builder for
        the statement's successor *)
     let rec stmt builder = function
-	A.Block sl -> List.fold_left stmt builder sl
+	A.Block (vl, sl) -> List.fold_left stmt builder sl
       | A.Expr e -> ignore (expr builder e); builder
       | A.Return e -> ignore (match fdecl.A.typ with
 	                 A.Void -> L.build_ret_void builder
@@ -185,11 +185,11 @@ let translate (globals, functions) =
 	  L.builder_at_end context merge_bb
 
       | A.For (e1, e2, e3, body) -> stmt builder
-	    ( A.Block [A.Expr e1 ; A.While (e2, A.Block [body ; A.Expr e3]) ] )
+      ( A.Block ([], [A.Expr e1 ; A.While (e2, A.Block ([], [body ; A.Expr e3])) ]))
     in
 
     (* Build the code for each statement in the function *)
-    let builder = stmt builder (A.Block fdecl.A.body) in
+    let builder = stmt builder (A.Block ([], fdecl.A.body)) in
 
     (* Add a return if the last block falls off the end *)
     add_terminal builder (match fdecl.A.typ with

--- a/hello-world-with-declare.cm
+++ b/hello-world-with-declare.cm
@@ -1,0 +1,10 @@
+//declare global just for shits
+int y;
+
+int main() {
+   char *x;
+   x = "hello world";
+   printf("%s\n", x);
+   return 0;
+}
+

--- a/my_tests/bad_construct.cm
+++ b/my_tests/bad_construct.cm
@@ -1,0 +1,8 @@
+int main() {
+    int x;
+    int y;
+    mint z;
+    z = <x, y>;
+    return 0;
+}
+/* Maybe declaring a mint through two ints should be legal, but currently it's not */

--- a/my_tests/bad_subscript.cm
+++ b/my_tests/bad_subscript.cm
@@ -1,0 +1,5 @@
+int main() {
+    stone x;
+    char *a;
+    return a[x];
+}

--- a/my_tests/fail-break.cm
+++ b/my_tests/fail-break.cm
@@ -1,0 +1,12 @@
+int main() {
+    int i;
+    int j;
+    j = 0;
+    for (i = 0; i < 5; i = i + 1) {
+        j = j + i;
+    }
+    break;
+    printf("The value of j is %d\n", j);
+    return 0;
+}
+

--- a/my_tests/forloop.cm
+++ b/my_tests/forloop.cm
@@ -1,0 +1,11 @@
+int main() {
+    int i;
+    int j;
+    j = 0;
+    for (i = 0; i < 5; i = i + 1) {
+        j = j + i;
+    }
+    printf("The value of j is %d\n", j);
+    return 0;
+}
+

--- a/my_tests/hello_world.cm
+++ b/my_tests/hello_world.cm
@@ -1,0 +1,6 @@
+int main() {
+    char *x;
+    x = "Hello World!";
+    printf("%s\n", x);
+    return 0;
+}

--- a/semant-declare-1.cm
+++ b/semant-declare-1.cm
@@ -1,0 +1,7 @@
+int main() {
+    int i;
+    int x;
+    for (i = 0; i < 5; i=i+1) {
+        int x; // should be error due to duplicate local
+    }
+}

--- a/semant-declare-2.cm
+++ b/semant-declare-2.cm
@@ -1,0 +1,7 @@
+int main() {
+    int i;
+    for (i = 0; i < 5; i=i+1) {
+        int x;
+        int x; // should be error due to duplicate local
+    }
+}

--- a/semant-declare-3.cm
+++ b/semant-declare-3.cm
@@ -2,6 +2,7 @@ int main() {
     int i;
     for (i = 0; i < 5; i=i+1) {
         int x;
+        x = 3;
     }
     int x; // this still gives an error, since this is declared at the same time
            // that int i is, I think.

--- a/semant-declare-3.cm
+++ b/semant-declare-3.cm
@@ -1,0 +1,8 @@
+int main() {
+    int i;
+    for (i = 0; i < 5; i=i+1) {
+        int x;
+    }
+    int x; // this still gives an error, since this is declared at the same time
+           // that int i is, I think.
+}

--- a/semant-declare-4.cm
+++ b/semant-declare-4.cm
@@ -1,0 +1,8 @@
+int main() {
+    int i;
+    for (i = 0; i < 5; i=i+1) {
+        int x;
+    }
+    x = 3; //this should give an error, since x doesn't exist anymore
+    return 0;
+}

--- a/semant-declare-4.cm
+++ b/semant-declare-4.cm
@@ -2,6 +2,7 @@ int main() {
     int i;
     for (i = 0; i < 5; i=i+1) {
         int x;
+        x = 4;
     }
     x = 3; //this should give an error, since x doesn't exist anymore
     return 0;

--- a/semant-declare-5.cm
+++ b/semant-declare-5.cm
@@ -1,0 +1,14 @@
+int main() {
+    int x;
+    {
+         int y;
+         {
+             int z;
+             z = 3;
+         }
+         y = 4;
+    }
+    x = 5;
+    printf("%d\n", x+y+z);
+    return 0;
+}

--- a/semant-declare-5.cm
+++ b/semant-declare-5.cm
@@ -1,14 +1,18 @@
 int main() {
     int x;
+    x = 1;
     {
          int y;
+         y = 3;
          {
              int z;
              z = 3;
+             printf("%d\n", z*y+x); // prints 10
          }
          y = 4;
+         printf("%d\n", y); //prints 4
     }
     x = 5;
-    printf("%d\n", x+y+z);
+    printf("%d\n", x); // prints 5
     return 0;
 }

--- a/semant-declare-6.cm
+++ b/semant-declare-6.cm
@@ -1,0 +1,9 @@
+int main() {
+    int i;
+    for (i = 0; i < 5; i=i+1) {
+        int x; 
+        x = 3;
+    }
+    i = 10;
+    return i;
+}

--- a/semant-declare-6.cm
+++ b/semant-declare-6.cm
@@ -2,7 +2,8 @@ int main() {
     int i;
     for (i = 0; i < 5; i=i+1) {
         int x; 
-        x = 3;
+        x = 3 * i;
+        printf("%d\n", x);
     }
     i = 10;
     return i;

--- a/semant.ml
+++ b/semant.ml
@@ -151,7 +151,7 @@ let check (globals, functions) =
 
       (* Definitely need to change this to support things which return lvalues,
        * e.g. dereferencing *)
-      | Assign(var, e) as ex -> print_endline "Assignment"; let lt = type_of_identifier var table
+      | Assign(var, e) as ex -> let lt = type_of_identifier var table
                                 and rt = expr table e in
         check_assign lt rt (Failure ("illegal assignment " ^ string_of_typ lt ^
 				     " = " ^ string_of_typ rt ^ " in " ^ 
@@ -182,7 +182,7 @@ let check (globals, functions) =
 
     (* Verify a statement or throw an exception *)
     let rec stmt table in_loop = function
-        Block (vl, sl) -> print_endline "In a block"; let rec check_block block_table = function
+        Block (vl, sl) -> let rec check_block block_table = function
            [Return _ as s] -> stmt block_table in_loop s
          | Return _ :: _ -> raise (Failure "nothing may follow a return")
          | (Block (_, _) as b) :: ss -> stmt block_table in_loop b; check_block
@@ -201,9 +201,6 @@ let check (globals, functions) =
           let new_table = List.fold_left (fun m (t, n) -> StringMap.add n t
             m) table vl in
           
-          List.iter (fun (s, _) -> print_endline s) (StringMap.bindings new_table);
-          print_endline "----------------";
-
           check_block new_table sl
             (* check the block with new lookup table *)
 

--- a/semant.ml
+++ b/semant.ml
@@ -185,10 +185,10 @@ let check (globals, functions) =
 
     (* Verify a statement or throw an exception *)
     let rec stmt in_loop = function
-	Block sl -> let rec check_block = function
+	Block (vl, sl) -> let rec check_block = function
            [Return _ as s] -> stmt in_loop s
          | Return _ :: _ -> raise (Failure "nothing may follow a return")
-         | Block sl :: ss -> check_block (sl @ ss)
+         | Block (vl, sl) :: ss -> check_block (sl @ ss)
          | s :: ss -> stmt in_loop s ; check_block ss
          | [] -> ()
         in check_block sl
@@ -209,7 +209,7 @@ let check (globals, functions) =
       | NullStmt -> ()
     in
 
-    stmt false (Block func.body)
+    stmt false (Block ([], func.body))
    
   in
   List.iter check_function functions

--- a/semant.ml
+++ b/semant.ml
@@ -30,7 +30,7 @@ let check (globals, functions) =
   (* Raise an exception of the given rvalue type cannot be assigned to
      the given lvalue type *)
   let check_assign lvaluet rvaluet err =
-     if lvaluet == rvaluet then lvaluet else raise err
+     if lvaluet = rvaluet then lvaluet else raise err
   in
    
   (**** Checking Global Variables ****)

--- a/semant.ml
+++ b/semant.ml
@@ -196,7 +196,7 @@ let check (globals, functions) =
             " in " ^ func.fname)) vl;
 
           report_duplicate (fun n -> "duplicate local " ^ n ^ " in " ^ func.fname)
-            (List.map snd vl);
+            ((List.map snd vl) @ (List.map fst (StringMap.bindings symbols)));
           
           ignore(symbols = List.fold_left (fun m (t, n) -> StringMap.add n t m)
             symbols (globals @ func.formals @ func.locals ));

--- a/semant.ml
+++ b/semant.ml
@@ -197,11 +197,14 @@ let check (globals, functions) =
 
           report_duplicate (fun n -> "duplicate local " ^ n ^ " in " ^ func.fname)
             ((List.map snd vl) @ (List.map fst (StringMap.bindings symbols)));
-          
-          ignore(symbols = List.fold_left (fun m (t, n) -> StringMap.add n t m)
-            symbols (globals @ func.formals @ func.locals ));
+          let old_symbols = symbols in
 
-          check_block sl
+          ignore(symbols = List.fold_left (fun m (t, n) -> StringMap.add n t m)
+            old_symbols (globals @ func.formals @ func.locals ));
+
+            check_block sl;
+          ignore(symbols = old_symbols);
+
       | Expr e -> ignore (expr e)
       | Return e -> let t = expr e in if t = func.typ then () else
          raise (Failure ("return gives " ^ string_of_typ t ^ " expected " ^


### PR DESCRIPTION
parser.mly / ast.ml / scanner.mll:
Changed the underlying grammar to allow declaration statements at any time. 

semant.ml:
Updated the semantic checker to check if a variable is declared in that specific scope. 

codegen.ml:
Updated codegen to declare variables when it joins a block

Note 1: Should probably add functionality to see if variable has been initialized when the value is used? This is not currently the case, and can lead to undefined behavior.
Note 2: Strange bug happens when you use an undeclared variable. Instead of semant telling you that you're using an undeclared unidentifier, it just gives you a "Not_found" exception with no qualification. Wonder why this is happening. Passing the "-a" flag shows that it occurs in codegen, which means that it gets past semant without semant complaining, which it shouldn't. Some testing shows it may have to do with the error not being detected if the expression is an actual in a function call -- not sure.
Note 3: Unlike in C, you cannot declare, say, int x inside of a block scope nested inside an outer scope which already has int x declared. e.g. something like

int main() {
   int x;
   int y;
   for (y = 0; y < 5; y = y + 1) {
       int x; //complains
   }
   return 0;
}

is illegal. This is for convenience for our implementation.